### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,16 @@
   }
 }
 
+html[data-theme="dark"] {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
+html[data-theme="light"] {
+  --background: #ffffff;
+  --foreground: #2d3748;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import DarkModeToggle from "@/components/DarkModeToggle";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -24,6 +25,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${inter.variable} font-sans antialiased`}>
         {children}
+        <DarkModeToggle />
       </body>
     </html>
   );

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function DarkModeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored);
+      document.documentElement.dataset.theme = stored;
+    } else {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const initial = prefersDark ? "dark" : "light";
+      setTheme(initial);
+      document.documentElement.dataset.theme = initial;
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === "dark" ? "light" : "dark";
+    setTheme(newTheme);
+    localStorage.setItem("theme", newTheme);
+    document.documentElement.dataset.theme = newTheme;
+  };
+
+  return (
+    <button
+      aria-label="Toggle Dark Mode"
+      onClick={toggleTheme}
+      className="fixed bottom-4 right-4 p-2 rounded-full bg-gray-200 text-gray-800"
+    >
+      {theme === "dark" ? "🌙" : "☀️"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add `DarkModeToggle` component with local storage
- update global CSS variables for manual theme switching
- include toggle component in the root layout

## Testing
- `npm install`
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_686cf835abe88327821a9251e958fc95